### PR TITLE
Update CH Core dependency

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -28,7 +28,7 @@ contact:
         use: work
 
 dependencies:
-  ch.fhir.ig.ch-core: 4.0.0-ballot
+  ch.fhir.ig.ch-core: current
   hl7.fhir.uv.ips: current
   hl7.fhir.eu.laboratory: current
   hl7.fhir.extensions.r5: 4.0.1


### PR DESCRIPTION
@lpg-tech können wir bitte auf den ci build von ch core wechseln, weil ich die kantonskürzel, die wir gerade in ch core integriert haben, für ch elm bräuchte? falls du einverstanden bist, bitte mergen.